### PR TITLE
Docker-compose file update :

### DIFF
--- a/week10/docker-compose.yml
+++ b/week10/docker-compose.yml
@@ -3,15 +3,16 @@ services:
   java:
     container_name: week10c
     build: ./
+    restart: on-failure
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080/tcp"
     depends_on:
       - db
   db:
     image: mysql
     container_name: mysql-we
     volumes:
-      - ./mysql-data:/var/lib/mysql
+      - /data/mysql
     environment:
       - MYSQL_ROOT_PASSWORD=password
       - MYSQL_DATABASE=fruitshop


### PR DESCRIPTION
- explicit port mapping 127.0.0.1:8080/8080/tcp(Optional)
- added restart option since java service container is more likely to start first before database container. Hence restart-on -failure will 
   make sure that it connects to database.
- changed volume from ./mysql-data:/var/lib/mysql  to /data/mysql (./mysql-data:/var/lib/mysql was giving error The designated data directory /var/lib/mysql/ is unusable.)